### PR TITLE
A fix for constructing the SHA1 url of remote repositories.

### DIFF
--- a/impl/src/main/java/com/redhat/ceylon/cmr/impl/URLContentStore.java
+++ b/impl/src/main/java/com/redhat/ceylon/cmr/impl/URLContentStore.java
@@ -66,7 +66,7 @@ public abstract class URLContentStore implements ContentStore, StructureBuilder 
 
     private String getFullPath(Node parent, String child) {
         return NodeUtils.getFullPath(parent, SEPARATOR) +
-                (SHA1.equals(child) ?  child : "/" + child);
+                (parent.hasBinaries() ?  child : "/" + child);
     }
 
     public OpenNode find(Node parent, String child) {


### PR DESCRIPTION
Hi Guys,

Previously, the sha1 for EXAMPLE_URL was constructed as EXAMPLE_URL/.sha1. For
instance, http://modules.ceylon-lang.org/default/default.car/.sha1 was the sha1
URL of the default package.

In this commit, the sha1 is constructed as EXAMPLE_URL.sha1, e.g.,
http://modules.ceylon-lang.org/default/default.car.sha1 as the sha1 of the
default package.

This commit also fixes the problem I have reported in Bug #345.

All the best,
Soheil
