### PR TITLE
add constants for dart artifacts

### DIFF
--- a/api/src/main/java/com/redhat/ceylon/cmr/api/ArtifactContext.java
+++ b/api/src/main/java/com/redhat/ceylon/cmr/api/ArtifactContext.java
@@ -40,6 +40,8 @@ public class ArtifactContext implements Serializable, ContentOptions {
     public static final String JAR = ".jar";
     public static final String JS_MODEL = "-model.js";
     public static final String JS = ".js";
+    public static final String DART = ".dart";
+    public static final String DART_MODEL = "-dartmodel.json";
     public static final String RESOURCES = "module-resources";
     public static final String SRC = ".src";
     public static final String MAVEN_SRC = "-sources.jar";
@@ -56,7 +58,8 @@ public class ArtifactContext implements Serializable, ContentOptions {
     // NB: SHA1 and ZIP are not part of this list because they are supposed
     // to be "composed" with other suffixes
     private static final String fileSuffixes[] = {
-        CAR, JAR, JS_MODEL, JS, RESOURCES, SRC, MAVEN_SRC, DOCS, SCRIPTS_ZIPPED
+        CAR, JAR, JS_MODEL, JS, DART, DART_MODEL, RESOURCES, SRC, MAVEN_SRC,
+        DOCS, SCRIPTS_ZIPPED
     };
     
     private static final String composedSuffixes[] = {

--- a/api/src/main/java/com/redhat/ceylon/cmr/api/ModuleQuery.java
+++ b/api/src/main/java/com/redhat/ceylon/cmr/api/ModuleQuery.java
@@ -21,6 +21,7 @@ public class ModuleQuery {
         JAR(ArtifactContext.JAR),
         JVM(ArtifactContext.CAR, ArtifactContext.JAR),
         JS(ArtifactContext.JS),
+        DART(ArtifactContext.DART),
         CODE(ArtifactContext.CAR, ArtifactContext.JAR, ArtifactContext.JS),
         CEYLON_CODE(ArtifactContext.CAR, ArtifactContext.JS),
         ALL(ArtifactContext.allSuffixes());

--- a/impl/src/main/java/com/redhat/ceylon/cmr/impl/AbstractRepository.java
+++ b/impl/src/main/java/com/redhat/ceylon/cmr/impl/AbstractRepository.java
@@ -442,7 +442,9 @@ public abstract class AbstractRepository implements CmrRepository {
                         // is it the right version?
                         || (suffix.equals(ArtifactContext.CAR)
                                 || suffix.equals(ArtifactContext.JS_MODEL) 
-                                || suffix.equals(ArtifactContext.JS))
+                                || suffix.equals(ArtifactContext.JS)
+                                || suffix.equals(ArtifactContext.DART)
+                                || suffix.equals(ArtifactContext.DART_MODEL))
                                 && !checkBinaryVersion(name, version, artifact, lookup)) {
                     if (lookup.getRetrieval() == Retrieval.ALL) {
                         break;


### PR DESCRIPTION
This PR adds minimal support for Dart file extensions. The need for this is an inability to "get" artifacts (storing isn't a problem!) from a repository manager with unknown suffixes:

```
com.redhat.ceylon.model.cmr.RepositoryException: Unknown suffix in simple-1.0.0.dart
	at com.redhat.ceylon.cmr.api.ArtifactContext.getSuffixFromFilename_(ArtifactContext.java:291)
	at com.redhat.ceylon.cmr.api.ArtifactContext.getSuffixFromFilename(ArtifactContext.java:259)
	at com.redhat.ceylon.cmr.api.ArtifactContext.getSuffixFromNode(ArtifactContext.java:250)
	at com.redhat.ceylon.cmr.impl.AbstractNodeRepositoryManager.getArtifactResult(AbstractNodeRepositoryManager.java:169)
	at com.redhat.ceylon.cmr.api.AbstractRepositoryManager.getArtifact(AbstractRepositoryManager.java:87)
```

The Dart backend is currently just an experiment. But it's a big experiment, and *potentially* useful. Without this patch, it will be much more difficult to let others try it out. So, if it doesn't look like it will cause problems, it would be great if this can be merged.